### PR TITLE
fix: Added rate limiter for querying server nbt data, fix injecting points for `handleVanllaQueryNbt`

### DIFF
--- a/src/main/java/fi/dy/masa/minihud/config/Configs.java
+++ b/src/main/java/fi/dy/masa/minihud/config/Configs.java
@@ -85,6 +85,7 @@ public class Configs implements IConfigHandler
         public static final ConfigHotkey        OPEN_CONFIG_GUI                     = new ConfigHotkey("openConfigGui", "H,C", "A hotkey to open the in-game Config GUI");
         public static final ConfigBoolean       REQUIRE_SNEAK                       = new ConfigBoolean("requireSneak", false, "Require the player to be sneaking to render the info line HUD");
         public static final ConfigHotkey        REQUIRED_KEY                        = new ConfigHotkey("requiredKey", "", KeybindSettings.MODIFIER_INGAME_EMPTY, "Require holding this key to render the HUD");
+        public static final ConfigInteger       SERVER_NBT_REQUEST_RATE             = new ConfigInteger("serverNbtRequestRate", 2, "Limit request rate for server entity data syncer");
         public static final ConfigHotkey        SET_DISTANCE_REFERENCE_POINT        = new ConfigHotkey("setDistanceReferencePoint", "", "A hotkey to store the player's current position\nas the reference point for the distance info line type");
         public static final ConfigHotkey        SHAPE_EDITOR                        = new ConfigHotkey("shapeEditor", "", "Opens the Shape Editor GUI for the selected shape");
         public static final ConfigBoolean       SHULKER_BOX_PREVIEW                 = new ConfigBoolean("shulkerBoxPreview", false, "Enables rendering a preview of the Shulker Box contents,\nwhen you hold shift while hovering over a Shulker Box item");
@@ -139,6 +140,7 @@ public class Configs implements IConfigHandler
                 MOVE_SHAPE_TO_PLAYER,
                 OPEN_CONFIG_GUI,
                 REQUIRED_KEY,
+                SERVER_NBT_REQUEST_RATE,
                 SET_DISTANCE_REFERENCE_POINT,
                 SHAPE_EDITOR,
 

--- a/src/main/java/fi/dy/masa/minihud/data/EntitiesDataStorage.java
+++ b/src/main/java/fi/dy/masa/minihud/data/EntitiesDataStorage.java
@@ -43,7 +43,7 @@ public class EntitiesDataStorage implements IClientTickHandler
     private String servuxVersion;
 
     private long serverTickTime = 0;
-    // To limit our request rate for the same object
+    // Requests to be executed
     private Set<BlockPos> pendingBlockEntitiesQueue = new LinkedHashSet<>();
     private Set<Integer> pendingEntitiesQueue = new LinkedHashSet<>();
     // To save vanilla query packet transaction

--- a/src/main/java/fi/dy/masa/minihud/data/EntitiesDataStorage.java
+++ b/src/main/java/fi/dy/masa/minihud/data/EntitiesDataStorage.java
@@ -7,6 +7,7 @@ import fi.dy.masa.malilib.network.ClientPlayHandler;
 import fi.dy.masa.malilib.network.IPluginClientPlayHandler;
 import fi.dy.masa.minihud.MiniHUD;
 import fi.dy.masa.minihud.Reference;
+import fi.dy.masa.minihud.config.Configs;
 import fi.dy.masa.minihud.mixin.IMixinDataQueryHandler;
 import fi.dy.masa.minihud.network.ServuxEntitiesHandler;
 import fi.dy.masa.minihud.network.ServuxEntitiesPacket;
@@ -67,7 +68,7 @@ public class EntitiesDataStorage implements IClientTickHandler
             // In this block, we do something every server tick
 
             // 5 queries / server tick
-            for (int i = 0; i < 5; i++)
+            for (int i = 0; i < Configs.Generic.SERVER_NBT_REQUEST_RATE.getIntegerValue(); i++)
             {
                 if (!pendingBlockEntitiesQueue.isEmpty())
                 {

--- a/src/main/java/fi/dy/masa/minihud/mixin/MixinClientPlayNetworkHandler.java
+++ b/src/main/java/fi/dy/masa/minihud/mixin/MixinClientPlayNetworkHandler.java
@@ -63,7 +63,7 @@ public abstract class MixinClientPlayNetworkHandler
         DataStorage.getInstance().setSimulationDistance(packet.simulationDistance());
     }
 
-    @Inject(method = "onNbtQueryResponse", at = @At("HEAD"))
+    @Inject(method = "onNbtQueryResponse", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/DataQueryHandler;handleQueryResponse(ILnet/minecraft/nbt/NbtCompound;)Z"))
     private void onQueryResponse(NbtQueryResponseS2CPacket packet, CallbackInfo ci)
     {
         EntitiesDataStorage.getInstance().handleVanillaQueryNbt(packet.getTransactionId(), packet.getNbt());

--- a/src/main/java/fi/dy/masa/minihud/network/ServuxEntitiesPacket.java
+++ b/src/main/java/fi/dy/masa/minihud/network/ServuxEntitiesPacket.java
@@ -333,6 +333,28 @@ public class ServuxEntitiesPacket implements IClientPayloadData
                     MiniHUD.logger.error("ServuxEntitiesPacket#fromPacket: error reading Metadata Response from packet: [{}]", e.getLocalizedMessage());
                 }
             }
+            case PACKET_S2C_BLOCK_NBT_RESPONSE_SIMPLE ->
+            {
+                try
+                {
+                    return ServuxEntitiesPacket.SimpleBlockResponse(input.readBlockPos(), input.readNbt());
+                }
+                catch (Exception e)
+                {
+                    MiniHUD.logger.error("ServuxEntitiesPacket#fromPacket: error reading Block Entity Response from packet: [{}]", e.getLocalizedMessage());
+                }
+            }
+            case PACKET_S2C_ENTITY_NBT_RESPONSE_SIMPLE ->
+            {
+                try
+                {
+                    return ServuxEntitiesPacket.SimpleEntityResponse(input.readVarInt(), input.readNbt());
+                }
+                catch (Exception e)
+                {
+                    MiniHUD.logger.error("ServuxEntitiesPacket#fromPacket: error reading Entity Response from packet: [{}]", e.getLocalizedMessage());
+                }
+            }
             default ->
             {
                 MiniHUD.logger.error("ServuxEntitiesPacket#fromPacket: Unknown packet type!");


### PR DESCRIPTION
- Invoke `EntitiesDataStorage.handleVanllaQueryNbt` on the right thread.
- Add SERVER_NBT_REQUEST_RATE config, limiting how many block entity and entities it can fetch every **server tick**, set it to N means to fetch N entities **AND** N block entities per tick.
- Some logic in fromPacket was mistakenly deleted and reverted in this PR.