### PR TITLE
fix: leash disappears when loading nbt

### DIFF
--- a/src/main/java/fi/dy/masa/minihud/mixin/IMixinLeashable.java
+++ b/src/main/java/fi/dy/masa/minihud/mixin/IMixinLeashable.java
@@ -1,0 +1,9 @@
+package fi.dy.masa.minihud.mixin;
+
+import net.minecraft.entity.Leashable;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(Leashable.class)
+public interface IMixinLeashable
+{
+}

--- a/src/main/java/fi/dy/masa/minihud/mixin/IMixinWorld.java
+++ b/src/main/java/fi/dy/masa/minihud/mixin/IMixinWorld.java
@@ -1,14 +1,14 @@
 package fi.dy.masa.minihud.mixin;
 
-import java.util.List;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.gen.Accessor;
+import net.minecraft.entity.Entity;
 import net.minecraft.world.World;
-import net.minecraft.world.chunk.BlockEntityTickInvoker;
+import net.minecraft.world.entity.EntityLookup;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
 
 @Mixin(World.class)
 public interface IMixinWorld
 {
-    @Accessor("blockEntityTickers")
-    List<BlockEntityTickInvoker> minihud_getBlockEntityTickers();
+    @Invoker("getEntityLookup")
+    EntityLookup<Entity> getEntityLookup();
 }

--- a/src/main/java/fi/dy/masa/minihud/util/EntityUtils.java
+++ b/src/main/java/fi/dy/masa/minihud/util/EntityUtils.java
@@ -1,6 +1,5 @@
 package fi.dy.masa.minihud.util;
 
-import fi.dy.masa.malilib.util.WorldUtils;
 import fi.dy.masa.minihud.mixin.IMixinEntity;
 import fi.dy.masa.minihud.mixin.IMixinWorld;
 import net.minecraft.client.MinecraftClient;
@@ -11,7 +10,6 @@ import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
 import net.minecraft.nbt.NbtList;
 import net.minecraft.text.Text;
-import net.minecraft.world.World;
 
 public class EntityUtils
 {
@@ -64,8 +62,6 @@ public class EntityUtils
     private static void readLeashableEntityCustomData(Entity entity, NbtCompound nbt)
     {
         MinecraftClient mc = MinecraftClient.getInstance();
-        World world = WorldUtils.getBestWorld(mc);
-        if (world == null) return;
         assert entity instanceof Leashable;
         Leashable leashable = (Leashable) entity;
         ((IMixinEntity) entity).readCustomDataFromNbt(nbt);
@@ -73,7 +69,8 @@ public class EntityUtils
         {
             leashable.getLeashData().unresolvedLeashData
                     .ifLeft(uuid ->
-                            leashable.attachLeash(((IMixinWorld) world).getEntityLookup().get(uuid), false))
+                            // We MUST use client-side world here.
+                            leashable.attachLeash(((IMixinWorld) mc.world).getEntityLookup().get(uuid), false))
                     .ifRight(pos ->
                             leashable.attachLeash(LeashKnotEntity.getOrCreate(mc.world, pos), false));
         }

--- a/src/main/java/fi/dy/masa/minihud/util/EntityUtils.java
+++ b/src/main/java/fi/dy/masa/minihud/util/EntityUtils.java
@@ -1,11 +1,17 @@
 package fi.dy.masa.minihud.util;
 
+import fi.dy.masa.malilib.util.WorldUtils;
 import fi.dy.masa.minihud.mixin.IMixinEntity;
+import fi.dy.masa.minihud.mixin.IMixinWorld;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.Leashable;
+import net.minecraft.entity.decoration.LeashKnotEntity;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
 import net.minecraft.nbt.NbtList;
 import net.minecraft.text.Text;
+import net.minecraft.world.World;
 
 public class EntityUtils
 {
@@ -45,6 +51,31 @@ public class EntityUtils
             }
         }
 
+        if (entity instanceof Leashable)
+        {
+            readLeashableEntityCustomData(entity, nbt);
+        }
+        else
+        {
+            ((IMixinEntity) entity).readCustomDataFromNbt(nbt);
+        }
+    }
+
+    private static void readLeashableEntityCustomData(Entity entity, NbtCompound nbt)
+    {
+        MinecraftClient mc = MinecraftClient.getInstance();
+        World world = WorldUtils.getBestWorld(mc);
+        if (world == null) return;
+        assert entity instanceof Leashable;
+        Leashable leashable = (Leashable) entity;
         ((IMixinEntity) entity).readCustomDataFromNbt(nbt);
+        if (leashable.getLeashData() != null && leashable.getLeashData().unresolvedLeashData != null)
+        {
+            leashable.getLeashData().unresolvedLeashData
+                    .ifLeft(uuid ->
+                            leashable.attachLeash(((IMixinWorld) world).getEntityLookup().get(uuid), false))
+                    .ifRight(pos ->
+                            leashable.attachLeash(LeashKnotEntity.getOrCreate(mc.world, pos), false));
+        }
     }
 }

--- a/src/main/resources/mixins.minihud.json
+++ b/src/main/resources/mixins.minihud.json
@@ -30,7 +30,8 @@
                 "MixinNeighborUpdateDebugRenderer",
                 "MixinServerEntityManager",
                 "MixinServerWorld",
-                "MixinSubtitlesHud"
+                "MixinSubtitlesHud",
+                "IMixinLeashable"
         ],
         "injectors": {
                 "defaultRequire": 1


### PR DESCRIPTION
![2024-06-27_00 17 53](https://github.com/sakura-ryoko/minihud/assets/66198935/f1c1b514-9842-4aca-9a2d-762803dba627)

When looking at the allay (will load its nbt into client entity), due to minecraft's some `instanceof ServerWorld` checks, the leash disappears.