### PR TITLE
fix: looking up server-side entities crahes on client thread

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ author = masa
 mod_file_name = minihud-fabric
 
 # Current mod version
-mod_version = 0.31.999-sakura.6
+mod_version = 0.31.999-entity-concurrent-mod-fix.1
 
 # Required malilib version
 malilib_version = 0.19.999-sakura.6

--- a/src/main/java/fi/dy/masa/minihud/gui/InventoryOverlayScreen.java
+++ b/src/main/java/fi/dy/masa/minihud/gui/InventoryOverlayScreen.java
@@ -130,4 +130,10 @@ public class InventoryOverlayScreen extends Screen
             }
         }
     }
+
+    @Override
+    public boolean shouldPause()
+    {
+        return false;
+    }
 }

--- a/src/main/java/fi/dy/masa/minihud/renderer/OverlayRendererVillagerInfo.java
+++ b/src/main/java/fi/dy/masa/minihud/renderer/OverlayRendererVillagerInfo.java
@@ -8,6 +8,7 @@ import fi.dy.masa.minihud.config.RendererToggle;
 import fi.dy.masa.minihud.data.EntitiesDataStorage;
 import fi.dy.masa.minihud.mixin.IMixinMerchantEntity;
 import fi.dy.masa.minihud.mixin.IMixinZombieVillagerEntity;
+import fi.dy.masa.minihud.util.EntityUtils;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.component.DataComponentTypes;
@@ -59,7 +60,7 @@ public class OverlayRendererVillagerInfo extends OverlayRendererBase
 
         if (Configs.Generic.VILLAGER_OFFER_ENCHANTMENT_BOOKS.getBooleanValue())
         {
-            List<VillagerEntity> librarians = world.getEntitiesByClass(VillagerEntity.class, box, villager -> villager.getVillagerData().getProfession() == VillagerProfession.LIBRARIAN);
+            List<VillagerEntity> librarians = EntityUtils.getEntitiesByClass(mc, VillagerEntity.class, box, villager -> villager.getVillagerData().getProfession() == VillagerProfession.LIBRARIAN);
 
             Map<Object2IntMap.Entry<RegistryEntry<Enchantment>>, Integer> lowestPrices = new HashMap<>();
             // Prepare
@@ -175,7 +176,7 @@ public class OverlayRendererVillagerInfo extends OverlayRendererBase
 
         if (Configs.Generic.VILLAGER_CONVERSION_TICKS.getBooleanValue())
         {
-            List<ZombieVillagerEntity> zombieVillagers = world.getEntitiesByClass(ZombieVillagerEntity.class, box, e -> true);
+            List<ZombieVillagerEntity> zombieVillagers = EntityUtils.getEntitiesByClass(mc, ZombieVillagerEntity.class, box, e -> true);
 
             for (ZombieVillagerEntity villager : zombieVillagers)
             {

--- a/src/main/java/fi/dy/masa/minihud/util/EntityUtils.java
+++ b/src/main/java/fi/dy/masa/minihud/util/EntityUtils.java
@@ -1,5 +1,6 @@
 package fi.dy.masa.minihud.util;
 
+import fi.dy.masa.malilib.util.WorldUtils;
 import fi.dy.masa.minihud.mixin.IMixinEntity;
 import fi.dy.masa.minihud.mixin.IMixinWorld;
 import net.minecraft.client.MinecraftClient;
@@ -10,6 +11,12 @@ import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
 import net.minecraft.nbt.NbtList;
 import net.minecraft.text.Text;
+import net.minecraft.util.math.Box;
+import net.minecraft.world.World;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
 
 public class EntityUtils
 {
@@ -74,5 +81,17 @@ public class EntityUtils
                     .ifRight(pos ->
                             leashable.attachLeash(LeashKnotEntity.getOrCreate(mc.world, pos), false));
         }
+    }
+
+    public static <T extends Entity> List<T> getEntitiesByClass(MinecraftClient mc, Class<T> entityClass, Box box, Predicate<? super T> predicate)
+    {
+        if (mc.world == null)
+        {
+            return Collections.emptyList();
+        }
+
+        List<Integer> entityIds = mc.world.getEntitiesByClass(entityClass, box, predicate).stream().map(it -> it.getId()).toList();
+        World world = WorldUtils.getBestWorld(mc);
+        return entityIds.stream().map(it -> (T) world.getEntityById(it)).toList();
     }
 }


### PR DESCRIPTION
Although this PR cannot 100% solve the ConcurrentModificationException (I don't want to write a lot of multi threading and future stuff), it can reduce the possibility of crashing to a very low level.

Some minor changes: I made the inventory preview screen not to pause the game.

It has been tested, OK to merge.