### PR TITLE
Use latest GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,12 +19,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: validate gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@v3
       - name: setup jdk ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: temurin
           java-version: ${{ matrix.java }}
       - name: make gradle wrapper executable
         if: ${{ runner.os != 'Windows' }}
@@ -33,7 +34,7 @@ jobs:
         run: ./gradlew build
       - name: capture build artifacts
         if: ${{ runner.os == 'Linux' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Artifacts
           path: build/libs/


### PR DESCRIPTION
The default Fabric template contains outdated actions, this brings GH actions up to date.

I used the action to build
[latest minihud](https://github.com/jans-forks/minihud-sakura/commit/30f8aec3f573200eb22626b9fcce876bf712ec5a)  and the resulting artefact has a different size, also I did not get the warning from Windows Defender about `WATAC`.

683.121 bytes (684 KB on disk) - updated gh actions
699.232 bytes (700 KB on disk) - [current release - 1.21-sakura.11](https://github.com/sakura-ryoko/minihud/releases/tag/1.21-sakura.11)


OT: would you consider using https://github.com/marketplace/actions/gh-release for releasing?