### PR TITLE
Fixed the Strange/Incorrect Sphere and Circle Shapes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build.number
 libs/
 run/
 .idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ Compiling
 =========
 * Clone the repository
 * Open a command prompt/terminal to the repository directory
-* run 'gradlew build'
+* run 'gradlew build' (or try '.\gradlew build' if this fails with Powershell)
 * The built jar file will be in build/libs/

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ mod_file_name = minihud-fabric
 mod_version = 0.34.0-sakura.3
 
 # Required malilib version
-malilib_version = 975d68adf7
+malilib_version = b41a9d0fa3
 
 # Minecraft, Fabric Loader and API and mappings versions
 minecraft_version_out = 1.21.4

--- a/src/main/java/fi/dy/masa/minihud/renderer/shapes/ShapeCircle.java
+++ b/src/main/java/fi/dy/masa/minihud/renderer/shapes/ShapeCircle.java
@@ -142,13 +142,7 @@ public class ShapeCircle extends ShapeCircleBase
             return true;
         }
 
-        double xAdj = x + outSide.getOffsetX();
-        double yAdj = y + outSide.getOffsetY();
-        double zAdj = z + outSide.getOffsetZ();
-        double distAdjSq = effectiveCenter.squaredDistanceTo(xAdj, yAdj, zAdj);
-        double diffAdj = radiusSq - distAdjSq;
-
-        return diffAdj > 0 && Math.abs(diff) < Math.abs(diffAdj);
+        return false;
     }
 
     public static List<SideQuad> buildStripsToQuadsForCircle(Long2ObjectOpenHashMap<SideQuad> strips,

--- a/src/main/java/fi/dy/masa/minihud/renderer/shapes/ShapeCircle.java
+++ b/src/main/java/fi/dy/masa/minihud/renderer/shapes/ShapeCircle.java
@@ -137,7 +137,7 @@ public class ShapeCircle extends ShapeCircleBase
         double distSq = effectiveCenter.squaredDistanceTo(x, y, z);
         double diff = radiusSq - distSq;
 
-        if (diff > 0)
+        if (diff >= 0)
         {
             return true;
         }

--- a/src/main/java/fi/dy/masa/minihud/util/shape/SphereUtils.java
+++ b/src/main/java/fi/dy/masa/minihud/util/shape/SphereUtils.java
@@ -191,18 +191,12 @@ public class SphereUtils
         double dist = center.squaredDistanceTo(x, y, z);
         double diff = squareRadius - dist;
 
-        if (diff > 0)
+        if (diff >= 0)
         {
             return true;
         }
-
-        double xAdj = (double) blockX + escapeDirection.getOffsetX() + 0.5;
-        double yAdj = (double) blockY + escapeDirection.getOffsetY() + 0.5;
-        double zAdj = (double) blockZ + escapeDirection.getOffsetZ() + 0.5;
-        double distAdj = center.squaredDistanceTo(xAdj, yAdj, zAdj);
-        double diffAdj = squareRadius - distAdj;
-
-        return diffAdj > 0 && Math.abs(diff) < Math.abs(diffAdj);
+        
+        return false;
     }
 
     /**

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -35,6 +35,6 @@
 
 	"depends": {
 		"minecraft": "1.21.4",
-		"malilib": ">=0.23.0-sakura.3"
+		"malilib": ">=0.23.0-sakura.4"
 	}
 }


### PR DESCRIPTION
I identified the source of the issue #78 as an unnecessary additional voxel/block check after such a voxel failed to be contained in the ring. There was an offset and then recheck on these failed voxels which allowed erroneous voxels to be included in the sphere. It's unclear to me what the original purpose of the extra check was for, but removing it fixes all the odd sphere shape issues, producing perfectly symetrical spheres and circles, as I found through basic tests. For very large shapes, it still doesn't perfectly match the common voxel sphere generator: https://www.plotz.co.uk/plotz-model.php?model=Sphere, but voxel spheres can be very finicky at these large scales, as I found by trying to replicate it in Matlab. Very small offsets can cause, different, but essentially correct and symmetrical spheres.