### PR TITLE
fixed issue with overwriting pose matrix in WorldRenderer.render

### DIFF
--- a/src/main/java/fi/dy/masa/minihud/renderer/RenderContainer.java
+++ b/src/main/java/fi/dy/masa/minihud/renderer/RenderContainer.java
@@ -127,7 +127,7 @@ public class RenderContainer
 
                     matrix4fstack.pushMatrix();
                     matrix4fstack.translate((float) (updatePos.x - cameraPos.x), (float) (updatePos.y - cameraPos.y), (float) (updatePos.z - cameraPos.z));
-                    renderer.draw(matrix4fstack.get(matrix4f), projMatrix);
+                    renderer.draw(matrix4fstack, projMatrix);
                     matrix4fstack.popMatrix();
                 }
 


### PR DESCRIPTION
I am mod developer and some users reported problem when they use MiniHUD with my mod. It turned out MiniHUD is overwriting model-view matrix that comes as parameter into `WorldRenderer.render` method. And this can cause problems when any code wants to use this matrix for something else after MiniHUD done its rendering.

In the code I updated, `matrix4f` parameter comes directly from `WorldRenderer.render` parameter. `matrix4fstack.get(matrix4f)` copies current matrix from the top of `Matrix4fStack` into `matrix4f`. Since `Matrix4fStack` extends `Matrix4f` we can pass it into methods expecting `Matrix4f` and copy operation is redundant. If we want to be safer we can create new instance of `Matrix4f` before the loop and call `matrix4fstack.get(newInstance)` instead.

I tested this change and it looks fine from the first glance (but obviously I am not very familiar with MiniHUD code or functionality). The same issue should exist in other versions/branches, but I verified 1.21 only.