### PR TITLE
feat: Add minute in real time and second in real life for world time formatter

### DIFF
--- a/src/main/java/fi/dy/masa/minihud/event/RenderHandler.java
+++ b/src/main/java/fi/dy/masa/minihud/event/RenderHandler.java
@@ -522,6 +522,8 @@ public class RenderHandler implements IRenderer
                 int hour = (int) ((dayTicks / 1000) + 6) % 24;
                 int min = (int) (dayTicks / 16.666666) % 60;
                 int sec = (int) (dayTicks / 0.277777) % 60;
+                int minIrl = (int) (dayTicks / 1200) % 20;
+                int secIrl = (int) (dayTicks / 20) % 60;
                 // Moonphase has 8 different states in MC
                 int moonNumber = (int) day % 8;
                 String moon;
@@ -540,6 +542,8 @@ public class RenderHandler implements IRenderer
                 str = str.replace("{HOUR}", String.format("%02d", hour));
                 str = str.replace("{MIN}",  String.format("%02d", min));
                 str = str.replace("{SEC}",  String.format("%02d", sec));
+                str = str.replace("{MINIRL}", String.format("%02d", minIrl));
+                str = str.replace("{SECIRL}", String.format("%02d", secIrl));
                 str = str.replace("{MOON}",  String.format("%s", moon));
 
                 this.addLine(str);

--- a/src/main/resources/assets/minihud/lang/en_us.json
+++ b/src/main/resources/assets/minihud/lang/en_us.json
@@ -99,7 +99,7 @@
     "minihud.config.generic.comment.conduitRangeOverlayThrough": "Uses the \"Render Through\" mode for rendering the Conduit Overlay Renderer",
     "minihud.config.generic.comment.coordinateFormat": "The format string for the coordinate line.\nNeeds to have three %%f format strings!\nDefault: x: %%.1f y: %%.1f z: %%.1f",
     "minihud.config.generic.comment.customModelTooltips": "Adds the first entry of any Custom Model Data",
-    "minihud.config.generic.comment.dateFormatMinecraft": "The format string for the Minecraft time.\nThe supported placeholders are: {DAY_1}, {DAY}, {HOUR}, {MIN}, {SEC}, {MOON}.\n{DAY_1} starts the day counter from 1, {DAY} starts from 0.",
+    "minihud.config.generic.comment.dateFormatMinecraft": "The format string for the Minecraft time.\nThe supported placeholders are: {DAY_1}, {DAY}, {HOUR}, {MIN}, {SEC}, {MINIRL}, {SECIRL}, {MOON}.\n{DAY_1} starts the day counter from 1, {DAY} starts from 0.",
     "minihud.config.generic.comment.dateFormatString": "The format string for real time, see the Java DateTimeFormatter\nclass Syntax for the format patterns, if needed.",
     "minihud.config.generic.comment.dateFormatType": "The format real time using the selected formatter options:\nRegular (§6Default§r): '§a2025-02-02_13.55.44§r' (§eyyyy-MM-dd_HH.mm.ss§r) \nISO Local: '§a2025-02-02T13:55:44.0939044§r' (§eyyyy-MM-ddTHH:mm:ss.n§r)\nISO Offset: '§a2025-02-02T13:55:44.0939044-05:00§r' (§eyyyy-MM-ddTHH:mm:ss.nZ§r)\nRFC1123: '§aSun, 2 Feb 2025 13:55:44 -0500§r' (§eEEE, dd MMM yyyy HH:mm:ss +HHMM§r) \nFormatted: This option uses the \"§bdateFormatString§r\" as input.",
     "minihud.config.generic.comment.debugDevelopmentMode": "Enables the Vanilla Development Mode toggle",

--- a/src/main/resources/assets/minihud/lang/es_es.json
+++ b/src/main/resources/assets/minihud/lang/es_es.json
@@ -99,7 +99,7 @@
     "minihud.config.generic.comment.conduitRangeOverlayThrough": "Uses the \"Render Through\" mode for rendering the Conduit Overlay Renderer",
     "minihud.config.generic.comment.coordinateFormat": "The format string for the coordinate line.\nNeeds to have three %%f format strings!\nDefault: x: %%.1f y: %%.1f z: %%.1f",
     "minihud.config.generic.comment.customModelTooltips": "Adds the first entry of any Custom Model Data",
-    "minihud.config.generic.comment.dateFormatMinecraft": "The format string for the Minecraft time.\nThe supported placeholders are: {DAY_1}, {DAY}, {HOUR}, {MIN}, {SEC}, {MOON}.\n{DAY_1} starts the day counter from 1, {DAY} starts from 0.",
+    "minihud.config.generic.comment.dateFormatMinecraft": "The format string for the Minecraft time.\nThe supported placeholders are: {DAY_1}, {DAY}, {HOUR}, {MIN}, {SEC}, {MINIRL}, {SECIRL}, {MOON}.\n{DAY_1} starts the day counter from 1, {DAY} starts from 0.",
     "minihud.config.generic.comment.dateFormatString": "The format string for real time, see the Java DateTimeFormatter\nclass Syntax for the format patterns, if needed.",
     "minihud.config.generic.comment.dateFormatType": "The format real time using the selected formatter options:\nRegular (§6Default§r): '§a2025-02-02_13.55.44§r' (§eyyyy-MM-dd_HH.mm.ss§r) \nISO Local: '§a2025-02-02T13:55:44.0939044§r' (§eyyyy-MM-ddTHH:mm:ss.n§r)\nISO Offset: '§a2025-02-02T13:55:44.0939044-05:00§r' (§eyyyy-MM-ddTHH:mm:ss.nZ§r)\nRFC1123: '§aSun, 2 Feb 2025 13:55:44 -0500§r' (§eEEE, dd MMM yyyy HH:mm:ss +HHMM§r) \nFormatted: This option uses the \"§bdateFormatString§r\" as input.",
     "minihud.config.generic.comment.debugDevelopmentMode": "Enables the Vanilla Development Mode toggle",

--- a/src/main/resources/assets/minihud/lang/fr_fr.json
+++ b/src/main/resources/assets/minihud/lang/fr_fr.json
@@ -99,7 +99,7 @@
     "minihud.config.generic.comment.conduitRangeOverlayThrough": "Uses the \"Render Through\" mode for rendering the Conduit Overlay Renderer",
     "minihud.config.generic.comment.coordinateFormat": "The format string for the coordinate line.\nNeeds to have three %%f format strings!\nDefault: x: %%.1f y: %%.1f z: %%.1f",
     "minihud.config.generic.comment.customModelTooltips": "Adds the first entry of any Custom Model Data",
-    "minihud.config.generic.comment.dateFormatMinecraft": "The format string for the Minecraft time.\nThe supported placeholders are: {DAY_1}, {DAY}, {HOUR}, {MIN}, {SEC}, {MOON}.\n{DAY_1} starts the day counter from 1, {DAY} starts from 0.",
+    "minihud.config.generic.comment.dateFormatMinecraft": "The format string for the Minecraft time.\nThe supported placeholders are: {DAY_1}, {DAY}, {HOUR}, {MIN}, {SEC}, {MINIRL}, {SECIRL}, {MOON}.\n{DAY_1} starts the day counter from 1, {DAY} starts from 0.",
     "minihud.config.generic.comment.dateFormatString": "The format string for real time, see the Java DateTimeFormatter\nclass Syntax for the format patterns, if needed.",
     "minihud.config.generic.comment.dateFormatType": "The format real time using the selected formatter options:\nRegular (§6Default§r): '§a2025-02-02_13.55.44§r' (§eyyyy-MM-dd_HH.mm.ss§r) \nISO Local: '§a2025-02-02T13:55:44.0939044§r' (§eyyyy-MM-ddTHH:mm:ss.n§r)\nISO Offset: '§a2025-02-02T13:55:44.0939044-05:00§r' (§eyyyy-MM-ddTHH:mm:ss.nZ§r)\nRFC1123: '§aSun, 2 Feb 2025 13:55:44 -0500§r' (§eEEE, dd MMM yyyy HH:mm:ss +HHMM§r) \nFormatted: This option uses the \"§bdateFormatString§r\" as input.",
     "minihud.config.generic.comment.debugDevelopmentMode": "Enables the Vanilla Development Mode toggle",

--- a/src/main/resources/assets/minihud/lang/it_it.json
+++ b/src/main/resources/assets/minihud/lang/it_it.json
@@ -99,7 +99,7 @@
     "minihud.config.generic.comment.conduitRangeOverlayThrough": "Uses the \"Render Through\" mode for rendering the Conduit Overlay Renderer",
     "minihud.config.generic.comment.coordinateFormat": "The format string for the coordinate line.\nNeeds to have three %%f format strings!\nDefault: x: %%.1f y: %%.1f z: %%.1f",
     "minihud.config.generic.comment.customModelTooltips": "Adds the first entry of any Custom Model Data",
-    "minihud.config.generic.comment.dateFormatMinecraft": "The format string for the Minecraft time.\nThe supported placeholders are: {DAY_1}, {DAY}, {HOUR}, {MIN}, {SEC}, {MOON}.\n{DAY_1} starts the day counter from 1, {DAY} starts from 0.",
+    "minihud.config.generic.comment.dateFormatMinecraft": "The format string for the Minecraft time.\nThe supported placeholders are: {DAY_1}, {DAY}, {HOUR}, {MIN}, {SEC}, {MINIRL}, {SECIRL}, {MOON}.\n{DAY_1} starts the day counter from 1, {DAY} starts from 0.",
     "minihud.config.generic.comment.dateFormatString": "The format string for real time, see the Java DateTimeFormatter\nclass Syntax for the format patterns, if needed.",
     "minihud.config.generic.comment.dateFormatType": "The format real time using the selected formatter options:\nRegular (§6Default§r): '§a2025-02-02_13.55.44§r' (§eyyyy-MM-dd_HH.mm.ss§r) \nISO Local: '§a2025-02-02T13:55:44.0939044§r' (§eyyyy-MM-ddTHH:mm:ss.n§r)\nISO Offset: '§a2025-02-02T13:55:44.0939044-05:00§r' (§eyyyy-MM-ddTHH:mm:ss.nZ§r)\nRFC1123: '§aSun, 2 Feb 2025 13:55:44 -0500§r' (§eEEE, dd MMM yyyy HH:mm:ss +HHMM§r) \nFormatted: This option uses the \"§bdateFormatString§r\" as input.",
     "minihud.config.generic.comment.debugDevelopmentMode": "Enables the Vanilla Development Mode toggle",

--- a/src/main/resources/assets/minihud/lang/ja_jp.json
+++ b/src/main/resources/assets/minihud/lang/ja_jp.json
@@ -99,7 +99,7 @@
     "minihud.config.generic.comment.conduitRangeOverlayThrough": "Uses the \"Render Through\" mode for rendering the Conduit Overlay Renderer",
     "minihud.config.generic.comment.coordinateFormat": "The format string for the coordinate line.\nNeeds to have three %%f format strings!\nDefault: x: %%.1f y: %%.1f z: %%.1f",
     "minihud.config.generic.comment.customModelTooltips": "Adds the first entry of any Custom Model Data",
-    "minihud.config.generic.comment.dateFormatMinecraft": "The format string for the Minecraft time.\nThe supported placeholders are: {DAY_1}, {DAY}, {HOUR}, {MIN}, {SEC}, {MOON}.\n{DAY_1} starts the day counter from 1, {DAY} starts from 0.",
+    "minihud.config.generic.comment.dateFormatMinecraft": "The format string for the Minecraft time.\nThe supported placeholders are: {DAY_1}, {DAY}, {HOUR}, {MIN}, {SEC}, {MINIRL}, {SECIRL}, {MOON}.\n{DAY_1} starts the day counter from 1, {DAY} starts from 0.",
     "minihud.config.generic.comment.dateFormatString": "The format string for real time, see the Java DateTimeFormatter\nclass Syntax for the format patterns, if needed.",
     "minihud.config.generic.comment.dateFormatType": "The format real time using the selected formatter options:\nRegular (§6Default§r): '§a2025-02-02_13.55.44§r' (§eyyyy-MM-dd_HH.mm.ss§r) \nISO Local: '§a2025-02-02T13:55:44.0939044§r' (§eyyyy-MM-ddTHH:mm:ss.n§r)\nISO Offset: '§a2025-02-02T13:55:44.0939044-05:00§r' (§eyyyy-MM-ddTHH:mm:ss.nZ§r)\nRFC1123: '§aSun, 2 Feb 2025 13:55:44 -0500§r' (§eEEE, dd MMM yyyy HH:mm:ss +HHMM§r) \nFormatted: This option uses the \"§bdateFormatString§r\" as input.",
     "minihud.config.generic.comment.debugDevelopmentMode": "Enables the Vanilla Development Mode toggle",

--- a/src/main/resources/assets/minihud/lang/ko_kr.json
+++ b/src/main/resources/assets/minihud/lang/ko_kr.json
@@ -99,7 +99,7 @@
     "minihud.config.generic.comment.conduitRangeOverlayThrough": "전달체 오버레이 렌더러에 \"렌더 투시\" 모드를 사용합니다.",
     "minihud.config.generic.comment.coordinateFormat": "좌표 정보 라인의 형식 문자열입니다.\n세 개의 %%f 형식 문자열이 필요합니다!\n기본값: x: %%.1f y: %%.1f z: %%.1f",
     "minihud.config.generic.comment.customModelTooltips": "사용자 지정 모델 데이터의 첫 번째 항목을 추가합니다.",
-    "minihud.config.generic.comment.dateFormatMinecraft": "마인크래프트 날짜에 대한 형식 문자열입니다.\n지원되는 자리 표시자는 다음과 같습니다: {DAY_1}, {DAY}, {HOUR}, {MIN}, {SEC}, {MOON}.\n{DAY_1}은 1부터 시작하고, {DAY}는 0부터 시작합니다.",
+    "minihud.config.generic.comment.dateFormatMinecraft": "마인크래프트 날짜에 대한 형식 문자열입니다.\n지원되는 자리 표시자는 다음과 같습니다: {DAY_1}, {DAY}, {HOUR}, {MIN}, {SEC}, {MINIRL}, {SECIRL}, {MOON}.\n{DAY_1}은 1부터 시작하고, {DAY}는 0부터 시작합니다.",
     "minihud.config.generic.comment.dateFormatString": "실제 시간을 위한 문자열 형식입니다. 필요한 경우 형식 패턴에\n대한 자바 DateTimeFormatter 클래스 구문을 참조하세요.",
     "minihud.config.generic.comment.dateFormatType": "선택된 형식 지정자 옵션을 사용하는 실제 시간 형식:\n레귤러 (§6기본값§r): '§a2025-02-02_13.55.44§r' (§eyyyy-MM-dd_HH.mm.ss§r)\nISO 로컬: '§a2025-02-02T13:55:44.0939044§r' (§eyyyy-MM-ddTHH:mm:ss.n§r)\nISO 오프셋: '§a2025-02-02T13:55:44.0939044-05:00§r' (§eyyyy-MM-ddTHH:mm:ss.nZ§r)\nRFC1123: '§aSun, 2 Feb 2025 13:55:44 -0500§r' (§eEEE, dd MMM yyyy HH:mm:ss +HHMM§r)\n지정 형식: 이 옵션은 \"§b데이터 형식 문자열§r\"을 입력값으로 사용합니다.",
     "minihud.config.generic.comment.debugDevelopmentMode": "바닐라 개발 모드 토글을 활성화합니다.",

--- a/src/main/resources/assets/minihud/lang/ru_ru.json
+++ b/src/main/resources/assets/minihud/lang/ru_ru.json
@@ -99,7 +99,7 @@
     "minihud.config.generic.comment.conduitRangeOverlayThrough": "Uses the \"Render Through\" mode for rendering the Conduit Overlay Renderer",
     "minihud.config.generic.comment.coordinateFormat": "The format string for the coordinate line.\nNeeds to have three %%f format strings!\nDefault: x: %%.1f y: %%.1f z: %%.1f",
     "minihud.config.generic.comment.customModelTooltips": "Adds the first entry of any Custom Model Data",
-    "minihud.config.generic.comment.dateFormatMinecraft": "The format string for the Minecraft time.\nThe supported placeholders are: {DAY_1}, {DAY}, {HOUR}, {MIN}, {SEC}, {MOON}.\n{DAY_1} starts the day counter from 1, {DAY} starts from 0.",
+    "minihud.config.generic.comment.dateFormatMinecraft": "The format string for the Minecraft time.\nThe supported placeholders are: {DAY_1}, {DAY}, {HOUR}, {MIN}, {SEC}, {MINIRL}, {SECIRL}, {MOON}.\n{DAY_1} starts the day counter from 1, {DAY} starts from 0.",
     "minihud.config.generic.comment.dateFormatString": "The format string for real time, see the Java DateTimeFormatter\nclass Syntax for the format patterns, if needed.",
     "minihud.config.generic.comment.dateFormatType": "The format real time using the selected formatter options:\nRegular (§6Default§r): '§a2025-02-02_13.55.44§r' (§eyyyy-MM-dd_HH.mm.ss§r) \nISO Local: '§a2025-02-02T13:55:44.0939044§r' (§eyyyy-MM-ddTHH:mm:ss.n§r)\nISO Offset: '§a2025-02-02T13:55:44.0939044-05:00§r' (§eyyyy-MM-ddTHH:mm:ss.nZ§r)\nRFC1123: '§aSun, 2 Feb 2025 13:55:44 -0500§r' (§eEEE, dd MMM yyyy HH:mm:ss +HHMM§r) \nFormatted: This option uses the \"§bdateFormatString§r\" as input.",
     "minihud.config.generic.comment.debugDevelopmentMode": "Enables the Vanilla Development Mode toggle",

--- a/src/main/resources/assets/minihud/lang/sv_se.json
+++ b/src/main/resources/assets/minihud/lang/sv_se.json
@@ -99,7 +99,7 @@
     "minihud.config.generic.comment.conduitRangeOverlayThrough": "Uses the \"Render Through\" mode for rendering the Conduit Overlay Renderer",
     "minihud.config.generic.comment.coordinateFormat": "The format string for the coordinate line.\nNeeds to have three %%f format strings!\nDefault: x: %%.1f y: %%.1f z: %%.1f",
     "minihud.config.generic.comment.customModelTooltips": "Adds the first entry of any Custom Model Data",
-    "minihud.config.generic.comment.dateFormatMinecraft": "The format string for the Minecraft time.\nThe supported placeholders are: {DAY_1}, {DAY}, {HOUR}, {MIN}, {SEC}, {MOON}.\n{DAY_1} starts the day counter from 1, {DAY} starts from 0.",
+    "minihud.config.generic.comment.dateFormatMinecraft": "The format string for the Minecraft time.\nThe supported placeholders are: {DAY_1}, {DAY}, {HOUR}, {MIN}, {SEC}, {MINIRL}, {SECIRL}, {MOON}.\n{DAY_1} starts the day counter from 1, {DAY} starts from 0.",
     "minihud.config.generic.comment.dateFormatString": "The format string for real time, see the Java DateTimeFormatter\nclass Syntax for the format patterns, if needed.",
     "minihud.config.generic.comment.dateFormatType": "The format real time using the selected formatter options:\nRegular (§6Default§r): '§a2025-02-02_13.55.44§r' (§eyyyy-MM-dd_HH.mm.ss§r) \nISO Local: '§a2025-02-02T13:55:44.0939044§r' (§eyyyy-MM-ddTHH:mm:ss.n§r)\nISO Offset: '§a2025-02-02T13:55:44.0939044-05:00§r' (§eyyyy-MM-ddTHH:mm:ss.nZ§r)\nRFC1123: '§aSun, 2 Feb 2025 13:55:44 -0500§r' (§eEEE, dd MMM yyyy HH:mm:ss +HHMM§r) \nFormatted: This option uses the \"§bdateFormatString§r\" as input.",
     "minihud.config.generic.comment.debugDevelopmentMode": "Enables the Vanilla Development Mode toggle",

--- a/src/main/resources/assets/minihud/lang/uk_ua.json
+++ b/src/main/resources/assets/minihud/lang/uk_ua.json
@@ -99,7 +99,7 @@
     "minihud.config.generic.comment.conduitRangeOverlayThrough": "Uses the \"Render Through\" mode for rendering the Conduit Overlay Renderer",
     "minihud.config.generic.comment.coordinateFormat": "The format string for the coordinate line.\nNeeds to have three %%f format strings!\nDefault: x: %%.1f y: %%.1f z: %%.1f",
     "minihud.config.generic.comment.customModelTooltips": "Adds the first entry of any Custom Model Data",
-    "minihud.config.generic.comment.dateFormatMinecraft": "The format string for the Minecraft time.\nThe supported placeholders are: {DAY_1}, {DAY}, {HOUR}, {MIN}, {SEC}, {MOON}.\n{DAY_1} starts the day counter from 1, {DAY} starts from 0.",
+    "minihud.config.generic.comment.dateFormatMinecraft": "The format string for the Minecraft time.\nThe supported placeholders are: {DAY_1}, {DAY}, {HOUR}, {MIN}, {SEC}, {MINIRL}, {SECIRL}, {MOON}.\n{DAY_1} starts the day counter from 1, {DAY} starts from 0.",
     "minihud.config.generic.comment.dateFormatString": "The format string for real time, see the Java DateTimeFormatter\nclass Syntax for the format patterns, if needed.",
     "minihud.config.generic.comment.dateFormatType": "The format real time using the selected formatter options:\nRegular (§6Default§r): '§a2025-02-02_13.55.44§r' (§eyyyy-MM-dd_HH.mm.ss§r) \nISO Local: '§a2025-02-02T13:55:44.0939044§r' (§eyyyy-MM-ddTHH:mm:ss.n§r)\nISO Offset: '§a2025-02-02T13:55:44.0939044-05:00§r' (§eyyyy-MM-ddTHH:mm:ss.nZ§r)\nRFC1123: '§aSun, 2 Feb 2025 13:55:44 -0500§r' (§eEEE, dd MMM yyyy HH:mm:ss +HHMM§r) \nFormatted: This option uses the \"§bdateFormatString§r\" as input.",
     "minihud.config.generic.comment.debugDevelopmentMode": "Enables the Vanilla Development Mode toggle",

--- a/src/main/resources/assets/minihud/lang/zh_cn.json
+++ b/src/main/resources/assets/minihud/lang/zh_cn.json
@@ -99,7 +99,7 @@
     "minihud.config.generic.comment.conduitRangeOverlayThrough": "使用\"Render Through(透视渲染)\"模式来渲染潮涌核心的范围",
     "minihud.config.generic.comment.coordinateFormat": "坐标信息行格式字符串\n需包含三个%%f占位符\n默认：“x: %%.1f y: %%.1f z: %%.1f”",
     "minihud.config.generic.comment.customModelTooltips": "添加任何自定义模型数据的首个条目",
-    "minihud.config.generic.comment.dateFormatMinecraft": "游戏内时间格式字符串\n可用占位符：{DAY_1}, {DAY}, {HOUR}, {MIN}, {SEC}, {MOON}\n{DAY_1}从1开始计数，{DAY}从0开始",
+    "minihud.config.generic.comment.dateFormatMinecraft": "游戏内时间格式字符串\n可用占位符：{DAY_1}, {DAY}, {HOUR}, {MIN}, {SEC}, {MINIRL}, {SECIRL}, {MOON}\n{DAY_1}从1开始计数，{DAY}从0开始",
     "minihud.config.generic.comment.dateFormatString": "实时格式字符串，请参考Java DateTimeFormatter\n类的格式模式语法（如有需要）",
     "minihud.config.generic.comment.dateFormatType": "使用选定格式选项格式化实时时间：\n常规（§6默认§r）：'§a2025-02-02_13.55.44§r'（§eyyyy-MM-dd_HH.mm.ss§r）\nISO本地：'§a2025-02-02T13:55:44.0939044§r'（§eyyyy-MM-ddTHH:mm:ss.n§r）\nISO偏移：'§a2025-02-02T13:55:44.0939044-05:00§r'（§eyyyy-MM-ddTHH:mm:ss.nZ§r）\nRFC1123：'§aSun, 2 Feb 2025 13:55:44 -0500§r'（§eEEE, dd MMM yyyy HH:mm:ss +HHMM§r）\n自定义格式：使用「§b日期格式字符串§r」作为输入",
     "minihud.config.generic.comment.debugDevelopmentMode": "启用原版开发者模式开关",

--- a/src/main/resources/assets/minihud/lang/zh_tw.json
+++ b/src/main/resources/assets/minihud/lang/zh_tw.json
@@ -99,7 +99,7 @@
     "minihud.config.generic.comment.conduitRangeOverlayThrough": "Uses the \"Render Through\" mode for rendering the Conduit Overlay Renderer",
     "minihud.config.generic.comment.coordinateFormat": "§6[玩家座標資訊]§f 中顯示格式的字串。\n字串中需要至少三個\"%%f\"\n預設值: \"x: %%.1f y: %%.1f z: %%.1f\"",
     "minihud.config.generic.comment.customModelTooltips": "Adds the first entry of any Custom Model Data",
-    "minihud.config.generic.comment.dateFormatMinecraft": "§6[格式化遊戲時間]§f 中顯示格式的字串\n支援的佔位符有：\n{DAY_1}（初始值為 1 的日）、{DAY}（初始值為 0 的日）、\n{HOUR}（小時）、{MIN}（分鐘）、{SEC}（秒）、\n{MOON}（月相）。",
+    "minihud.config.generic.comment.dateFormatMinecraft": "§6[格式化遊戲時間]§f 中顯示格式的字串\n支援的佔位符有：\n{DAY_1}（初始值為 1 的日）、{DAY}（初始值為 0 的日）、\n{HOUR}（小時）、{MIN}（分鐘）、{SEC}（秒）、{MINIRL}（真實分鐘）、{SECIRL}（真實秒）、\n{MOON}（月相）。",
     "minihud.config.generic.comment.dateFormatString": "The format string for real time, see the Java DateTimeFormatter\nclass Syntax for the format patterns, if needed.",
     "minihud.config.generic.comment.dateFormatType": "The format real time using the selected formatter options:\nRegular (§6Default§r): '§a2025-02-02_13.55.44§r' (§eyyyy-MM-dd_HH.mm.ss§r) \nISO Local: '§a2025-02-02T13:55:44.0939044§r' (§eyyyy-MM-ddTHH:mm:ss.n§r)\nISO Offset: '§a2025-02-02T13:55:44.0939044-05:00§r' (§eyyyy-MM-ddTHH:mm:ss.nZ§r)\nRFC1123: '§aSun, 2 Feb 2025 13:55:44 -0500§r' (§eEEE, dd MMM yyyy HH:mm:ss +HHMM§r) \nFormatted: This option uses the \"§bdateFormatString§r\" as input.",
     "minihud.config.generic.comment.debugDevelopmentMode": "Enables the Vanilla Development Mode toggle",


### PR DESCRIPTION
Add a `MINIRL` (minute in real time) and a `SECIRL` (second in real time) for [`TIME_WORLD_FORMATTED`](https://github.com/sakura-ryoko/minihud/blob/master/src/main/java/fi/dy/masa/minihud/event/RenderHandler.java#L514)

For example, when the `dayTicks` are 12000, `{HOUR}:{MIN}:{SEC}` will be 18:00:00, and `{MINIRL}:{SECIRL}` will be 10:00 (for the 10th minute from starting of day).

<details>
<summary>Footage</summary>
<p>

Format string:`MC time: (day {DAY}) {HOUR}:{MIN}:{SEC} ({MINIRL}:{SECIRL})`
![2025-06-03_14 52 54](https://github.com/user-attachments/assets/4fe93f26-2c8b-4165-ab53-c1e1289666c2)
> Apologize for such small font

</p>
</details> 