### PR TITLE
Fix: infoWorldTimeFormatted option not displayed correctly

### DIFF
--- a/src/main/java/fi/dy/masa/minihud/info/entity/InfoLineCopperAging.java
+++ b/src/main/java/fi/dy/masa/minihud/info/entity/InfoLineCopperAging.java
@@ -126,7 +126,7 @@ public class InfoLineCopperAging extends InfoLine
 			}
 			else
 			{
-				final long diff = (world.getDefaultClockTime() - age) * -1;
+				final long diff = (world.getGameTime() - age) * -1;
 				final String formatted = this.formatCountdown(diff);
 
 				if (formatted.isEmpty())

--- a/src/main/java/fi/dy/masa/minihud/info/world/InfoLineTimeWorldFormatted.java
+++ b/src/main/java/fi/dy/masa/minihud/info/world/InfoLineTimeWorldFormatted.java
@@ -45,7 +45,7 @@ public class InfoLineTimeWorldFormatted extends InfoLine
 
         try
         {
-            final long timeDay = world.getGameTime();
+            final long timeDay = world.getDefaultClockTime();
             final long day = (int) (timeDay / 24000);
             // 1 tick = 3.6 seconds in MC (0.2777... seconds IRL)
             final int dayTicks = (int) (timeDay % 24000);


### PR DESCRIPTION
The infoWorldTimeFormatted option used the server time (**excluding** increases due to going to sleep) to calculate the current time of day instead of either the amount of time since day 1 or since a command that changed time was executed (e.g. ```/time set 12000t```). 

This PR changes world.getGameTime() to world.getDefaultClockTime().

This means that time is calculated not using server time, but rather the amount of time passed since day 1 or command execution to more accurately reflect the actual day count.


Fixes https://github.com/sakura-ryoko/minihud/issues/210